### PR TITLE
Remove  role="contentinfo" from footer

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -8,7 +8,7 @@
             </div><!--.site-content-->
 
 
-            <footer id="site-footer" class="site-footer page-footer" role="contentinfo">
+            <footer id="site-footer" class="site-footer page-footer">
                 <div id="footer-row" class="row">
                     <div class="col-md-6 footer-left">
                         <?php 


### PR DESCRIPTION
A footer is semantic and accessible and the the role="contentinfo" is not needed